### PR TITLE
Develop

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,7 @@ USER root
 
 RUN pip install datascience \
     ipywidgets \
+    ml-datasets \
     openpyxl \
     otter-grader \
     plotly \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
                 stage('Test') {
                     steps {
                         container('podman') {
-                            sh 'podman run -it --rm localhost/$IMAGE_NAME python -c "import datascience; import ipywidgets; import openpyxl; import plotly; import sklearn; import seaborn; import statsmodels; import math; import matplotlib; import matplotlib.pyplot; import numpy; import otter; import pandas; import scipy; import spacy;"'
+                            sh 'podman run -it --rm localhost/$IMAGE_NAME python -c "import datascience; import ipywidgets; import openpyxl; import plotly; import sklearn; import seaborn; import statsmodels; import math; import matplotlib; import matplotlib.pyplot; import numpy; import otter; import pandas; import scipy; import spacy; import ml_datasets"'
                             sh 'podman run -it --rm localhost/$IMAGE_NAME python -m pytest --pyargs spacy'
                             sh 'podman run -d --name=$IMAGE_NAME --rm -p 8888:8888 localhost/$IMAGE_NAME start-notebook.sh --NotebookApp.token="jenkinstest"'
                             sh 'sleep 10 && curl -v http://localhost:8888/lab?token=jenkinstest 2>&1 | grep -P "HTTP\\S+\\s200\\s+[\\w\\s]+\\s*$"'


### PR DESCRIPTION
pip install ml-datasets

These were suddenly not available for the current spacy tests: 
ml_datasets.imdb_sentiment.v1
ml_datasets.cmu_movies.v1
ml_datasets.dbpedia

FAILED tests/test_registry_population.py::test_registry_entries - AssertionError: Registry 'readers' missing entries: ml_datasets.dbpedia.v1, ml_datasets.imdb_sentiment.v1, ml_datasets.cmu_movies.v1

